### PR TITLE
Fall back to full node keypair if seeder section or keys are missing

### DIFF
--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -206,7 +206,12 @@ func (c *HTTPClient) initialKeyPairs() error {
 
 	c.crawlerKeyPair, err = c.config.Seeder.CrawlerConfig.SSL.LoadPrivateKeyPair()
 	if err != nil {
-		return fmt.Errorf("error loading crawler config: %w", err)
+		// Fall back to just using the full node certs in this case
+		// This should only happen on old installations that didn't have the crawler in the config initially
+		c.crawlerKeyPair, err = c.config.FullNode.SSL.LoadPrivateKeyPair()
+		if err != nil {
+			return fmt.Errorf("error loading crawler config: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Old installations of chia will not have the seeder section. This adds a fallback to the full node cert, so there aren't any errors when creating the http client. See https://github.com/Chia-Network/chia-exporter/issues/38