### PR TITLE
get_wallets requires some data

### DIFF
--- a/pkg/rpc/wallet.go
+++ b/pkg/rpc/wallet.go
@@ -91,6 +91,11 @@ func (s *WalletService) GetNetworkInfo() (*GetWalletNetworkInfoResponse, *http.R
 	return r, resp, nil
 }
 
+// GetWalletsOptions wallet rpc -> get_wallets
+type GetWalletsOptions struct {
+	Type types.WalletType `json:"type"`
+}
+
 // GetWalletsResponse wallet rpc -> get_wallets
 type GetWalletsResponse struct {
 	Success     bool                `json:"success"`
@@ -99,8 +104,8 @@ type GetWalletsResponse struct {
 }
 
 // GetWallets wallet rpc -> get_wallets
-func (s *WalletService) GetWallets() (*GetWalletsResponse, *http.Response, error) {
-	request, err := s.NewRequest("get_wallets", nil)
+func (s *WalletService) GetWallets(opts *GetWalletsOptions) (*GetWalletsResponse, *http.Response, error) {
+	request, err := s.NewRequest("get_wallets", opts)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
get_wallets sends an error if you don't give it the curl equivalent of `-d '{}'`

But also, there is an option in that RPC endpoint to specify the wallet type like `-d '{"type":6}'`

You can test my claim just by running some Go like:

```
package main

import (
	"log"

	"github.com/chia-network/go-chia-libs/pkg/rpc"
)

func main() {
	client, err := rpc.NewClient(rpc.ConnectionModeHTTP)
	if err != nil {
		log.Print(err)
	}

	ws, _, err := client.WalletService.GetWallets()
	if err != nil {
		log.Print(err)
	}

	if len(ws.Wallets) == 0 {
		log.Print("no wallets") // this will _always_ be true because the RPC endpoint returns an error string
	}
}

```