### PR TITLE
Tuple Type

### DIFF
--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -64,14 +64,24 @@ func setType(field *reflect.Value, fillValue interface{}) {
 		return
 	}
 	switch field.Kind() {
-	case reflect.String:
-		if stringed, ok := fillValue.(string); ok {
-			field.SetString(stringed)
-		}
+	case reflect.Bool:
+	case reflect.Int:
+	case reflect.Int8:
+	case reflect.Int16:
+	case reflect.Int32:
+	case reflect.Int64:
+	case reflect.Uint:
 	case reflect.Uint8:
 		// numeric looking things seem to unmarshal generically into float64
 		if floated, ok := fillValue.(float64); ok {
 			field.SetUint(uint64(floated))
+		}
+	case reflect.Uint16:
+	case reflect.Uint32:
+	case reflect.Uint64:
+	case reflect.String:
+		if stringed, ok := fillValue.(string); ok {
+			field.SetString(stringed)
 		}
 	case reflect.Struct:
 		// The only nested struct we support for now is Option[T]

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -46,6 +46,18 @@ func (t *Tuple[T]) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
+	vp := reflect.ValueOf(&t.value)
+	v := vp.Elem()
+	for i := 0; i < v.NumField(); i++ {
+		switch v.Field(i).Kind() {
+		case reflect.String:
+			if stringed, ok := tmpMap[i].(string); ok {
+				v.Field(i).SetString(stringed)
+			}
+			// @TODO handle other types
+		}
+	}
+
 	t.isPresent = true
 	return nil
 }

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -20,6 +20,11 @@ type Tuple[T any] struct {
 	value     T
 }
 
+// Value returns the underlying struct
+func (t Tuple[T]) Value() T {
+	return t.value
+}
+
 // MarshalJSON custom marshaller for tuple wrapped structs
 func (t Tuple[T]) MarshalJSON() ([]byte, error) {
 	v := reflect.ValueOf(t.value)

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -1,0 +1,51 @@
+package tuple
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+)
+
+// Some builds a Tupe when value is present.
+func Some[T any](value T) Tuple[T] {
+	return Tuple[T]{
+		isPresent: true,
+		value:     value,
+	}
+}
+
+// Tuple Wrapper for structs that encodes/decodes json as a tuple, rather than dict
+type Tuple[T any] struct {
+	isPresent bool
+	value     T
+}
+
+// MarshalJSON custom marshaller for tuple wrapped structs
+func (t Tuple[T]) MarshalJSON() ([]byte, error) {
+	v := reflect.ValueOf(t.value)
+
+	values := make([]interface{}, v.NumField())
+
+	for i := 0; i < v.NumField(); i++ {
+		values[i] = v.Field(i).Interface()
+	}
+
+	return json.Marshal(values)
+}
+
+// UnmarshalJSON decodes Option from json.
+func (t *Tuple[T]) UnmarshalJSON(b []byte) error {
+	if bytes.Equal(b, []byte("null")) {
+		t.isPresent = false
+		return nil
+	}
+
+	var tmpMap []interface{}
+	err := json.Unmarshal(b, &tmpMap)
+	if err != nil {
+		return err
+	}
+
+	t.isPresent = true
+	return nil
+}

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"reflect"
-
-	"github.com/samber/mo"
 )
 
 // Some builds a Tupe when value is present.
@@ -36,63 +34,26 @@ func (t Tuple[T]) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON decodes Option from json.
+// This works by creating a temp []interface{}, where each item in the slice is a pointer to the fields of the underlying
+// tuple struct. Since it's pre-filled with pointers, unmarshal fills the pointers and checks the types
 func (t *Tuple[T]) UnmarshalJSON(b []byte) error {
 	if bytes.Equal(b, []byte("null")) {
 		t.isPresent = false
 		return nil
 	}
 
-	var tmpMap []interface{}
+	v := reflect.ValueOf(&t.value).Elem()
+	tmpMap := make([]interface{}, v.NumField())
+	tmv := reflect.ValueOf(&tmpMap).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		tmv.Index(i).Set(field.Addr())
+	}
 	err := json.Unmarshal(b, &tmpMap)
 	if err != nil {
 		return err
 	}
 
-	vp := reflect.ValueOf(&t.value)
-	v := vp.Elem()
-	for i := 0; i < v.NumField(); i++ {
-		field := v.Field(i)
-		setType(&field, tmpMap[i])
-	}
-
 	t.isPresent = true
 	return nil
-}
-
-func setType(field *reflect.Value, fillValue interface{}) {
-	if fillValue == nil {
-		return
-	}
-	switch field.Kind() {
-	case reflect.Bool:
-	case reflect.Int:
-	case reflect.Int8:
-	case reflect.Int16:
-	case reflect.Int32:
-	case reflect.Int64:
-	case reflect.Uint:
-	case reflect.Uint8:
-		// numeric looking things seem to unmarshal generically into float64
-		if floated, ok := fillValue.(float64); ok {
-			field.SetUint(uint64(floated))
-		}
-	case reflect.Uint16:
-	case reflect.Uint32:
-	case reflect.Uint64:
-	case reflect.String:
-		if stringed, ok := fillValue.(string); ok {
-			field.SetString(stringed)
-		}
-	case reflect.Struct:
-		// The only nested struct we support for now is Option[T]
-		actualType := field.Type().Name()
-		switch actualType {
-		case "Option[string]":
-			os := mo.Some(fillValue.(string))
-			osrp := reflect.ValueOf(&os)
-			osr := osrp.Elem()
-			field.Set(osr)
-		}
-		// @TODO handle other types
-	}
 }

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -1,0 +1,46 @@
+package tuple_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/chia-network/go-chia-libs/pkg/tuple"
+)
+
+// basically the same as sent_to in transactions
+type testTypeForTuples struct {
+	Peer                   string
+	MempoolInclusionStatus uint8
+	Error                  mo.Option[string]
+}
+
+var (
+	expectedStruct = []tuple.Tuple[testTypeForTuples]{
+		tuple.Some(testTypeForTuples{
+			Peer:                   "9a6aac3959e9192c16156cd73f954791934d79804eed131f20666f228c6cf192",
+			MempoolInclusionStatus: 3,
+			Error:                  mo.Some("INVALID_FEE_TOO_CLOSE_TO_ZERO"),
+		}),
+		tuple.Some(testTypeForTuples{
+			Peer:                   "9a6aac3959e9192c16156cd73f954791934d79804eed131f20666f228c6cf192",
+			MempoolInclusionStatus: 1,
+		}),
+	}
+	expectedJSON = `[["9a6aac3959e9192c16156cd73f954791934d79804eed131f20666f228c6cf192",3,"INVALID_FEE_TOO_CLOSE_TO_ZERO"],["9a6aac3959e9192c16156cd73f954791934d79804eed131f20666f228c6cf192",1,null]]`
+)
+
+func TestTuple_MarshalJSON(t *testing.T) {
+	marshalled, err := json.Marshal(expectedStruct)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedJSON, string(marshalled))
+}
+
+func TestTuple_UnmarshalJSON(t *testing.T) {
+	var unmarshalled []tuple.Tuple[testTypeForTuples]
+	err := json.Unmarshal([]byte(expectedJSON), &unmarshalled)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStruct, unmarshalled)
+}

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -2,6 +2,7 @@ package tuple_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/samber/mo"
@@ -43,4 +44,68 @@ func TestTuple_UnmarshalJSON(t *testing.T) {
 	err := json.Unmarshal([]byte(expectedJSON), &unmarshalled)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedStruct, unmarshalled)
+}
+
+func BenchmarkTuple_UnmarshalJSON(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		var unmarshalled []tuple.Tuple[testTypeForTuples]
+		err := json.Unmarshal([]byte(expectedJSON), &unmarshalled)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+// Test struct, same as SentTo
+// sent_to: List[Tuple[str, uint8, Optional[str]]]
+type BenchStruct struct {
+	Peer                   string
+	MempoolInclusionStatus uint8
+	Error                  mo.Option[string]
+}
+
+// UnmarshalJSON unmarshals the BenchStruct tuple into the struct
+func (s *BenchStruct) UnmarshalJSON(buf []byte) error {
+	tmp := []interface{}{&s.Peer, &s.MempoolInclusionStatus, &s.Error}
+	wantLen := len(tmp)
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if g, e := len(tmp), wantLen; g != e {
+		return fmt.Errorf("wrong number of fields in SentTo: %d != %d", g, e)
+	}
+
+	return nil
+}
+
+// This is a silly test, becuse its a test that only exists to ensure the benchmark test is actually doing the same work
+// as the real tuple test. But without it, the benchmark is not known to be valid
+func TestTuple_UnmarshalJSON_NoTuple(t *testing.T) {
+	var unmarshalled []BenchStruct
+	expectedStruct := []BenchStruct{
+		BenchStruct{
+			Peer:                   "9a6aac3959e9192c16156cd73f954791934d79804eed131f20666f228c6cf192",
+			MempoolInclusionStatus: 3,
+			Error:                  mo.Some("INVALID_FEE_TOO_CLOSE_TO_ZERO"),
+		},
+		BenchStruct{
+			Peer:                   "9a6aac3959e9192c16156cd73f954791934d79804eed131f20666f228c6cf192",
+			MempoolInclusionStatus: 1,
+		},
+	}
+	err := json.Unmarshal([]byte(expectedJSON), &unmarshalled)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStruct, unmarshalled)
+}
+
+// BenchmarkTuple_UnmarshalJSON_NoTuple tests the old way (custom marshal/unmarshal) on a struct
+// Vs the Tuple wrapper with all the reflection
+func BenchmarkTuple_UnmarshalJSON_NoTuple(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		var unmarshalled []BenchStruct
+		err := json.Unmarshal([]byte(expectedJSON), &unmarshalled)
+		if err != nil {
+			b.Error(err)
+		}
+	}
 }

--- a/pkg/types/bytes.go
+++ b/pkg/types/bytes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"strings"
 )
 
 // Bytes is a wrapper around []byte that marshals down to hex and more closely matches types in chia-blockchain
@@ -12,6 +13,22 @@ type Bytes []byte
 // String Converts to hex string
 func (b Bytes) String() string {
 	return fmt.Sprintf("0x%s", hex.EncodeToString(b))
+}
+
+// BytesFromHexString parses a hex string into Bytes
+func BytesFromHexString(hexstr string) (Bytes, error) {
+	hexstr = strings.TrimLeft(hexstr, `"`)
+	hexstr = strings.TrimRight(hexstr, `"`)
+	hexstr = strings.TrimPrefix(hexstr, `0x`)
+
+	hexStrBytes := []byte(hexstr)
+	dest := make(Bytes, hex.DecodedLen(len(hexStrBytes)))
+	_, err := hex.Decode(dest, hexStrBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return dest, nil
 }
 
 // MarshalJSON marshals Bytes into hex for json


### PR DESCRIPTION
Initial stab at generic tuple struct wrapper for json encoding/decoding without custom decoders for every tuple variant in the rpcs.

Idea was to basically allow wrapping a struct type with Tuple, and have the Tuple handle the (un)marshalling as if it were a tuple. Requires the struct to have the same order as the Tuple, and the struct keys are basically only useful in Go - they're dropped in json.

Definitely going to want to see how this performs. The farther I go down this road, the worse it seems like its going to be.