### PR TITLE
Add configoption

### DIFF
--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -7,12 +7,7 @@ import (
 )
 
 // LoadPrivateKeyPair loads the private key pair for the SSLConfig
-func (s *SSLConfig) LoadPrivateKeyPair() (*tls.Certificate, error) {
-	rootPath, err := GetChiaRootPath()
-	if err != nil {
-		return nil, err
-	}
-
+func (s *SSLConfig) LoadPrivateKeyPair(rootPath string) (*tls.Certificate, error) {
 	if s.PrivateCRT == "" || s.PrivateKey == "" {
 		return nil, errors.New("missing private key or cert. Ensure config.yaml is up to date with the latest changes")
 	}
@@ -22,12 +17,7 @@ func (s *SSLConfig) LoadPrivateKeyPair() (*tls.Certificate, error) {
 }
 
 // LoadPublicKeyPair loads the public key pair for the SSLConfig
-func (s *SSLConfig) LoadPublicKeyPair() (*tls.Certificate, error) {
-	rootPath, err := GetChiaRootPath()
-	if err != nil {
-		return nil, err
-	}
-
+func (s *SSLConfig) LoadPublicKeyPair(rootPath string) (*tls.Certificate, error) {
 	if s.PublicCRT == "" || s.PublicKey == "" {
 		return nil, errors.New("missing public key or cert. Ensure config.yaml is up to date with the latest changes")
 	}

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -224,31 +224,31 @@ func (c *HTTPClient) Do(req *rpcinterface.Request, v interface{}) (*http.Respons
 func (c *HTTPClient) initialKeyPairs() error {
 	var err error
 
-	c.nodeKeyPair, err = c.config.FullNode.SSL.LoadPrivateKeyPair()
+	c.nodeKeyPair, err = c.config.FullNode.SSL.LoadPrivateKeyPair(c.config.ChiaRoot)
 	if err != nil {
 		return fmt.Errorf("error loading full node config: %w", err)
 	}
 
-	c.farmerKeyPair, err = c.config.Farmer.SSL.LoadPrivateKeyPair()
+	c.farmerKeyPair, err = c.config.Farmer.SSL.LoadPrivateKeyPair(c.config.ChiaRoot)
 	if err != nil {
 		return fmt.Errorf("error loading farmer config: %w", err)
 	}
 
-	c.harvesterKeyPair, err = c.config.Harvester.SSL.LoadPrivateKeyPair()
+	c.harvesterKeyPair, err = c.config.Harvester.SSL.LoadPrivateKeyPair(c.config.ChiaRoot)
 	if err != nil {
 		return fmt.Errorf("error loading harvester config: %w", err)
 	}
 
-	c.walletKeyPair, err = c.config.Wallet.SSL.LoadPrivateKeyPair()
+	c.walletKeyPair, err = c.config.Wallet.SSL.LoadPrivateKeyPair(c.config.ChiaRoot)
 	if err != nil {
 		return fmt.Errorf("error loading wallet config: %w", err)
 	}
 
-	c.crawlerKeyPair, err = c.config.Seeder.CrawlerConfig.SSL.LoadPrivateKeyPair()
+	c.crawlerKeyPair, err = c.config.Seeder.CrawlerConfig.SSL.LoadPrivateKeyPair(c.config.ChiaRoot)
 	if err != nil {
 		// Fall back to just using the full node certs in this case
 		// This should only happen on old installations that didn't have the crawler in the config initially
-		c.crawlerKeyPair, err = c.config.FullNode.SSL.LoadPrivateKeyPair()
+		c.crawlerKeyPair, err = c.config.FullNode.SSL.LoadPrivateKeyPair(c.config.ChiaRoot)
 		if err != nil {
 			return fmt.Errorf("error loading crawler config: %w", err)
 		}

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -38,8 +38,8 @@ const (
 )
 
 // NewClient returns a new RPC Client
-func NewClient(connectionMode ConnectionMode, options ...rpcinterface.ClientOptionFunc) (*Client, error) {
-	cfg, err := config.GetChiaConfig()
+func NewClient(connectionMode ConnectionMode, configOption rpcinterface.ConfigOptionFunc, options ...rpcinterface.ClientOptionFunc) (*Client, error) {
+	cfg, err := configOption()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpc/client_test.go
+++ b/pkg/rpc/client_test.go
@@ -23,6 +23,7 @@ func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *Client) {
 		t.Fatal(err)
 	}
 	client, err := NewClient(ConnectionModeHTTP,
+		WithAutoConfig(),
 		WithDaemonPort(uint16(p)),
 		WithNodePort(uint16(p)),
 		WithFarmerPort(uint16(p)),

--- a/pkg/rpc/clientoptions.go
+++ b/pkg/rpc/clientoptions.go
@@ -4,9 +4,24 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/chia-network/go-chia-libs/pkg/config"
 	"github.com/chia-network/go-chia-libs/pkg/httpclient"
 	"github.com/chia-network/go-chia-libs/pkg/rpcinterface"
 )
+
+// WithAutoConfig automatically loads chia config from CHIA_ROOT
+func WithAutoConfig() rpcinterface.ConfigOptionFunc {
+	return func() (*config.ChiaConfig, error) {
+		return config.GetChiaConfig()
+	}
+}
+
+// WithManualConfig allows supplying a manual configuration for the RPC client
+func WithManualConfig(cfg config.ChiaConfig) rpcinterface.ConfigOptionFunc {
+	return func() (*config.ChiaConfig, error) {
+		return &cfg, nil
+	}
+}
 
 // WithBaseURL sets the host for RPC requests
 func WithBaseURL(url *url.URL) rpcinterface.ClientOptionFunc {

--- a/pkg/rpc/readme.md
+++ b/pkg/rpc/readme.md
@@ -18,7 +18,7 @@ import (
 )
 
 func main() {
-	client, err := rpc.NewClient(rpc.ConnectionModeHTTP)
+	client, err := rpc.NewClient(rpc.ConnectionModeHTTP, rpc.WithAutoConfig())
 	if err != nil {
 		// error happened
 	}
@@ -37,7 +37,7 @@ import (
 )
 
 func main() {
-	client, err := rpc.NewClient(rpc.ConnectionModeWebsocket)
+	client, err := rpc.NewClient(rpc.ConnectionModeWebsocket, rpc.WithAutoConfig())
 	if err != nil {
 		// error happened
 	}
@@ -62,7 +62,7 @@ import (
 )
 
 func main() {
-	client, err := rpc.NewClient(rpc.ConnectionModeWebsocket)
+	client, err := rpc.NewClient(rpc.ConnectionModeWebsocket, rpc.WithAutoConfig())
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
@@ -90,7 +90,7 @@ import (
 )
 
 func main() {
-	client, err := rpc.NewClient(rpc.ConnectionModeWebsocket)
+	client, err := rpc.NewClient(rpc.ConnectionModeWebsocket, rpc.WithAutoConfig())
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
@@ -118,7 +118,7 @@ There are two helper functions to subscribe to events that come over the websock
 #### HTTP Mode
 
 ```go
-client, err := rpc.NewClient(rpc.ConnectionModeHTTP)
+client, err := rpc.NewClient(rpc.ConnectionModeHTTP, rpc.WithAutoConfig())
 if err != nil {
 	log.Fatal(err)
 }
@@ -143,7 +143,7 @@ if transactions.Transactions.IsPresent() {
 
 ```go
 func main() {
-	client, err := rpc.NewClient(rpc.ConnectionModeWebsocket)
+	client, err := rpc.NewClient(rpc.ConnectionModeWebsocket, rpc.WithAutoConfig())
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
@@ -217,7 +217,7 @@ if state.BlockchainState.IsPresent() {
 When using HTTP mode, there is an optional request cache that can be enabled with a configurable cache duration. To use the cache, initialize the client with the `rpc.WithCache()` option like the following example:
 
 ```go
-client, err := rpc.NewClient(rpc.ConnectionModeHTTP, rpc.WithCache(60 * time.Second))
+client, err := rpc.NewClient(rpc.ConnectionModeHTTP, rpc.WithAutoConfig(), rpc.WithCache(60 * time.Second))
 if err != nil {
 	// error happened
 }

--- a/pkg/rpcinterface/clientoptions.go
+++ b/pkg/rpcinterface/clientoptions.go
@@ -1,4 +1,11 @@
 package rpcinterface
 
+import (
+	"github.com/chia-network/go-chia-libs/pkg/config"
+)
+
 // ClientOptionFunc can be used to customize a new RPC client.
 type ClientOptionFunc func(client Client) error
+
+// ConfigOptionFunc used to specify how to load configuration for the RPC client
+type ConfigOptionFunc func() (*config.ChiaConfig, error)

--- a/pkg/websocketclient/websocketclient.go
+++ b/pkg/websocketclient/websocketclient.go
@@ -268,7 +268,7 @@ func (c *WebsocketClient) reconnectLoop() {
 func (c *WebsocketClient) initialKeyPairs() error {
 	var err error
 
-	c.daemonKeyPair, err = c.config.DaemonSSL.LoadPrivateKeyPair()
+	c.daemonKeyPair, err = c.config.DaemonSSL.LoadPrivateKeyPair(c.config.ChiaRoot)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds two options for supplying configuration to the app. 
1. Autoconfig: The old default method. Will automatically locate CHIA_ROOT based on env or the default location, and load config, certs, etc from there
```client, err := rpc.NewClient(rpc.ConnectionModeHTTP, rpc.WithAutoConfig(), opts...)```

2. Manual Config: You provide your own config struct to the client, which will then be used for all ports, certs, etc.
```client, err := rpc.NewClient(rpc.ConnectionModeHTTP, rpc.WithManualConfig(config.ChiaConfig{...}), opts...)```


I plan to make a subsequent PR to do "lazy" ssl cert loading, so that if all you want is full node, you don't need to provide config for all the other services up front