### PR TITLE
feat: add `datalayer` connection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ type ChiaConfig struct {
 	Harvester       HarvesterConfig `yaml:"harvester"`
 	Wallet          WalletConfig    `yaml:"wallet"`
 	Seeder          SeederConfig    `yaml:"seeder"`
+	DataLayer       DataLayerConfig `yaml:"data_layer"`
 	SelectedNetwork string          `yaml:"selected_network"`
 }
 
@@ -56,6 +57,12 @@ type SeederConfig struct {
 
 // CrawlerConfig is the subsection of the seeder config specific to the crawler
 type CrawlerConfig struct {
+	PortConfig `yaml:",inline"`
+	SSL        SSLConfig `yaml:"ssl"`
+}
+
+// DataLayerConfig datalayer configuration section
+type DataLayerConfig struct {
 	PortConfig `yaml:",inline"`
 	SSL        SSLConfig `yaml:"ssl"`
 }

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -334,6 +334,14 @@ func (c *HTTPClient) httpClientForService(service rpcinterface.ServiceType) (*ht
 			}
 		}
 		client = c.crawlerClient
+	case rpcinterface.ServiceDataLayer:
+		if c.datalayerClient == nil {
+			c.datalayerClient, err = c.generateHTTPClientForService(rpcinterface.ServiceDataLayer)
+			if err != nil {
+				return nil, err
+			}
+		}
+		client = c.datalayerClient
 	}
 
 	if client == nil {

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -46,6 +46,10 @@ type HTTPClient struct {
 	crawlerPort    uint16
 	crawlerKeyPair *tls.Certificate
 	crawlerClient  *http.Client
+
+	datalayerPort    uint16
+	datalayerKeyPair *tls.Certificate
+	datalayerClient  *http.Client
 }
 
 // NewHTTPClient returns a new HTTP client that satisfies the rpcinterface.Client interface
@@ -60,6 +64,7 @@ func NewHTTPClient(cfg *config.ChiaConfig, options ...rpcinterface.ClientOptionF
 		harvesterPort: cfg.Harvester.RPCPort,
 		walletPort:    cfg.Wallet.RPCPort,
 		crawlerPort:   cfg.Seeder.CrawlerConfig.RPCPort,
+		datalayerPort: cfg.DataLayer.RPCPort,
 	}
 
 	// Sets the default host. Can be overridden by client options
@@ -226,6 +231,14 @@ func (c *HTTPClient) generateHTTPClientForService(service rpcinterface.ServiceTy
 			}
 		}
 		keyPair = c.crawlerKeyPair
+	case rpcinterface.ServiceDataLayer:
+		if c.datalayerKeyPair == nil {
+			c.datalayerKeyPair, err = c.config.DataLayer.SSL.LoadPrivateKeyPair(c.config.ChiaRoot)
+			if err != nil {
+				return nil, err
+			}
+		}
+		keyPair = c.datalayerKeyPair
 	default:
 		return nil, fmt.Errorf("unknown service")
 	}
@@ -266,6 +279,8 @@ func (c *HTTPClient) portForService(service rpcinterface.ServiceType) uint16 {
 		port = c.walletPort
 	case rpcinterface.ServiceCrawler:
 		port = c.crawlerPort
+	case rpcinterface.ServiceDataLayer:
+		port = c.datalayerPort
 	}
 
 	return port

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -23,6 +23,7 @@ type Client struct {
 	FarmerService    *FarmerService
 	HarvesterService *HarvesterService
 	CrawlerService   *CrawlerService
+	DataLayerService *DataLayerService
 
 	websocketHandlers []rpcinterface.WebsocketResponseHandler
 }
@@ -67,6 +68,7 @@ func NewClient(connectionMode ConnectionMode, configOption rpcinterface.ConfigOp
 	c.FarmerService = &FarmerService{client: c}
 	c.HarvesterService = &HarvesterService{client: c}
 	c.CrawlerService = &CrawlerService{client: c}
+	c.DataLayerService = &DataLayerService{client: c}
 
 	return c, nil
 }

--- a/pkg/rpc/client_test.go
+++ b/pkg/rpc/client_test.go
@@ -64,11 +64,11 @@ func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *Client) {
 			ChiaRoot:   tmpDir,
 			DaemonPort: portConf.RPCPort,
 			DaemonSSL:  sslConf,
-			FullNode: config.FullNodeConfig{
+			Farmer: config.FarmerConfig{
 				PortConfig: portConf,
 				SSL:        sslConf,
 			},
-			Farmer: config.FarmerConfig{
+			FullNode: config.FullNodeConfig{
 				PortConfig: portConf,
 				SSL:        sslConf,
 			},
@@ -85,6 +85,10 @@ func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *Client) {
 					PortConfig: portConf,
 					SSL:        sslConf,
 				},
+			},
+			DataLayer: config.DataLayerConfig{
+				PortConfig: portConf,
+				SSL:        sslConf,
 			},
 		}))
 	if err != nil {

--- a/pkg/rpc/datalayer.go
+++ b/pkg/rpc/datalayer.go
@@ -1,0 +1,22 @@
+package rpc
+
+import (
+	"net/http"
+
+	"github.com/chia-network/go-chia-libs/pkg/rpcinterface"
+)
+
+// DataLayerService encapsulates data layer RPC methods
+type DataLayerService struct {
+	client *Client
+}
+
+// NewRequest returns a new request specific to the wallet service
+func (s *DataLayerService) NewRequest(rpcEndpoint rpcinterface.Endpoint, opt interface{}) (*rpcinterface.Request, error) {
+	return s.client.NewRequest(rpcinterface.ServiceFullNode, rpcEndpoint, opt)
+}
+
+// Do is just a shortcut to the client's Do method
+func (s *DataLayerService) Do(req *rpcinterface.Request, v interface{}) (*http.Response, error) {
+	return s.client.Do(req, v)
+}

--- a/pkg/rpc/datalayer.go
+++ b/pkg/rpc/datalayer.go
@@ -13,7 +13,7 @@ type DataLayerService struct {
 
 // NewRequest returns a new request specific to the wallet service
 func (s *DataLayerService) NewRequest(rpcEndpoint rpcinterface.Endpoint, opt interface{}) (*rpcinterface.Request, error) {
-	return s.client.NewRequest(rpcinterface.ServiceFullNode, rpcEndpoint, opt)
+	return s.client.NewRequest(rpcinterface.ServiceDataLayer, rpcEndpoint, opt)
 }
 
 // Do is just a shortcut to the client's Do method

--- a/pkg/rpcinterface/servicetype.go
+++ b/pkg/rpcinterface/servicetype.go
@@ -27,4 +27,7 @@ const (
 
 	// ServiceCrawler crawler service
 	ServiceCrawler
+
+	// ServiceDataLayer datalayer service
+	ServiceDataLayer
 )


### PR DESCRIPTION
In this PR, we aim to add a data layer connection in the `HttpClient` and read the `data_layer` configuration from `chia-config`.