### PR TITLE
Allow passing in a whole config section as a json/yaml string

### DIFF
--- a/pkg/rpc/daemon.go
+++ b/pkg/rpc/daemon.go
@@ -169,7 +169,7 @@ func (s *DaemonService) IsRunning(opts *IsRunningOptions) (*IsRunningResponse, *
 }
 
 // DaemonDeleteAllKeysOpts options for delete all keys request
-type DaemonDeleteAllKeysOpts struct {}
+type DaemonDeleteAllKeysOpts struct{}
 
 // DaemonDeleteAllKeysResponse response when deleting all keys
 type DaemonDeleteAllKeysResponse struct {


### PR DESCRIPTION
Enables something like the following in chia-tools:
`--set network_overrides.constants='{"myrandomnet":{"DIFFICULTY_CONSTANT_FACTOR":44445555,"GENESIS_CHALLENGE":e739da31bcc4ab1767d9f1ca99eb3cec765fb3b3508f82e090374d5913d24806}}'`