### PR TITLE
Dont return nil, nil, nil when block record is nil - the response has…

### DIFF
--- a/pkg/rpc/fullnode.go
+++ b/pkg/rpc/fullnode.go
@@ -213,11 +213,6 @@ func (s *FullNodeService) GetBlockRecordByHeight(opts *GetBlockByHeightOptions) 
 		return nil, resp, err
 	}
 
-	// I believe this happens when the node is not yet synced to this height
-	if record == nil || record.BlockRecord.IsAbsent() {
-		return nil, nil, nil
-	}
-
 	return record, resp, nil
 }
 


### PR DESCRIPTION
… success: False, and we need to be able to see that downstream