### PR TITLE
Add function to generate all chia certs in memory

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     container: golang:1
     steps:
+      - name: Add safe Git directory
+        uses: Chia-Network/actions/git-mark-workspace-safe@main
+
       - uses: actions/checkout@v4
 
       - name: Get latest chiavdf libs

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -231,7 +231,7 @@ func GenerateAndWriteAllCerts(outDir string, privateCACert *x509.Certificate, pr
 		return fmt.Errorf("error generating certificates: %w", err)
 	}
 
-	// Copy the private CA cert/key
+	// Write the private CA cert/key
 	err = os.WriteFile(path.Join(outDir, "ca", "private_ca.crt"), allCerts.PrivateCA.Certificate, 0600)
 	if err != nil {
 		return fmt.Errorf("error copying private_ca.crt: %w", err)
@@ -246,7 +246,7 @@ func GenerateAndWriteAllCerts(outDir string, privateCACert *x509.Certificate, pr
 		return fmt.Errorf("error copying private_ca.key: %w", err)
 	}
 
-	// Next, copy the chia_ca cert/key
+	// Next, write the chia_ca cert/key
 	err = os.WriteFile(path.Join(outDir, "ca", "chia_ca.crt"), chiaCACrtBytes, 0600)
 	if err != nil {
 		return fmt.Errorf("error copying chia_ca.crt: %w", err)
@@ -260,7 +260,7 @@ func GenerateAndWriteAllCerts(outDir string, privateCACert *x509.Certificate, pr
 		crtKey := nodeHelpers.fetch(allCerts)
 		_, _, err = WriteCertAndKey(crtKey.Certificate, crtKey.PrivateKey, path.Join(outDir, node, nodeHelpers.certKeyBase))
 		if err != nil {
-			return fmt.Errorf("error writing private pair for %s: %w", node, err)
+			return fmt.Errorf("error writing public pair for %s: %w", node, err)
 		}
 	}
 

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -17,83 +17,83 @@ import (
 )
 
 type fieldHelpers struct {
-	setter      func(certs *ChiaCertificates, pair *CertificateKeyPair)
-	getter      func(certs *ChiaCertificates) *CertificateKeyPair
+	assign      func(certs *ChiaCertificates, pair *CertificateKeyPair)
+	fetch       func(certs *ChiaCertificates) *CertificateKeyPair
 	certKeyBase string
 }
 
 var (
 	privateNodes = map[string]fieldHelpers{
 		"full_node": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateFullNode = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateFullNode },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateFullNode = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateFullNode },
 			certKeyBase: "private_full_node",
 		},
 		"wallet": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateWallet = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateWallet },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateWallet = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateWallet },
 			certKeyBase: "private_wallet",
 		},
 		"farmer": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateFarmer = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateFarmer },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateFarmer = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateFarmer },
 			certKeyBase: "private_farmer",
 		},
 		"harvester": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateHarvester = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateHarvester },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateHarvester = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateHarvester },
 			certKeyBase: "private_harvester",
 		},
 		"timelord": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateTimelord = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateTimelord },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateTimelord = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateTimelord },
 			certKeyBase: "private_timelord",
 		},
 		"crawler": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateCrawler = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateCrawler },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateCrawler = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateCrawler },
 			certKeyBase: "private_crawler",
 		},
 		"data_layer": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateDatalayer = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateDatalayer },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateDatalayer = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateDatalayer },
 			certKeyBase: "private_data_layer",
 		},
 		"daemon": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateDaemon = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateDaemon },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateDaemon = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateDaemon },
 			certKeyBase: "private_daemon",
 		},
 	}
 	publicNodes = map[string]fieldHelpers{
 		"full_node": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicFullNode = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicFullNode },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicFullNode = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicFullNode },
 			certKeyBase: "public_full_node",
 		},
 		"wallet": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicWallet = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicWallet },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicWallet = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicWallet },
 			certKeyBase: "public_wallet",
 		},
 		"farmer": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicFarmer = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicFarmer },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicFarmer = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicFarmer },
 			certKeyBase: "public_farmer",
 		},
 		"introducer": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicIntroducer = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicIntroducer },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicIntroducer = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicIntroducer },
 			certKeyBase: "public_introducer",
 		},
 		"timelord": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicTimelord = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicTimelord },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicTimelord = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicTimelord },
 			certKeyBase: "public_timelord",
 		},
 		"data_layer": {
-			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicDatalayer = p },
-			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicDatalayer },
+			assign:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicDatalayer = p },
+			fetch:       func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicDatalayer },
 			certKeyBase: "public_data_layer",
 		},
 	}
@@ -185,7 +185,7 @@ func GenerateAllCerts(privateCACert *x509.Certificate, privateCAKey *rsa.Private
 		if err != nil {
 			return nil, fmt.Errorf("error generating public pair for %s: %w", node, err)
 		}
-		nodeData.setter(chiaCerts, &CertificateKeyPair{
+		nodeData.assign(chiaCerts, &CertificateKeyPair{
 			Certificate: cert,
 			PrivateKey:  key,
 		})
@@ -197,7 +197,7 @@ func GenerateAllCerts(privateCACert *x509.Certificate, privateCAKey *rsa.Private
 		if err != nil {
 			return nil, fmt.Errorf("error generating private pair for %s: %w", node, err)
 		}
-		nodeData.setter(chiaCerts, &CertificateKeyPair{
+		nodeData.assign(chiaCerts, &CertificateKeyPair{
 			Certificate: cert,
 			PrivateKey:  key,
 		})
@@ -257,7 +257,7 @@ func GenerateAndWriteAllCerts(outDir string, privateCACert *x509.Certificate, pr
 	}
 
 	for node, nodeHelpers := range publicNodes {
-		crtKey := nodeHelpers.getter(allCerts)
+		crtKey := nodeHelpers.fetch(allCerts)
 		crt, key, err := EncodeCertAndKeyToPEM(crtKey.Certificate, crtKey.PrivateKey)
 		if err != nil {
 			return fmt.Errorf("error encoding public pair for %s: %w", node, err)
@@ -275,7 +275,7 @@ func GenerateAndWriteAllCerts(outDir string, privateCACert *x509.Certificate, pr
 	}
 
 	for node, nodeHelpers := range privateNodes {
-		crtKey := nodeHelpers.getter(allCerts)
+		crtKey := nodeHelpers.fetch(allCerts)
 		crt, key, err := EncodeCertAndKeyToPEM(crtKey.Certificate, crtKey.PrivateKey)
 		if err != nil {
 			return fmt.Errorf("error encoding private pair for %s: %w", node, err)

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -16,24 +16,86 @@ import (
 	"time"
 )
 
+type fieldHelpers struct {
+	setter      func(certs *ChiaCertificates, pair *CertificateKeyPair)
+	getter      func(certs *ChiaCertificates) *CertificateKeyPair
+	certKeyBase string
+}
+
 var (
-	privateNodeNames = []string{
-		"full_node",
-		"wallet",
-		"farmer",
-		"harvester",
-		"timelord",
-		"crawler",
-		"data_layer",
-		"daemon",
+	privateNodes = map[string]fieldHelpers{
+		"full_node": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateFullNode = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateFullNode },
+			certKeyBase: "private_full_node",
+		},
+		"wallet": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateWallet = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateWallet },
+			certKeyBase: "private_wallet",
+		},
+		"farmer": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateFarmer = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateFarmer },
+			certKeyBase: "private_farmer",
+		},
+		"harvester": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateHarvester = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateHarvester },
+			certKeyBase: "private_harvester",
+		},
+		"timelord": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateTimelord = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateTimelord },
+			certKeyBase: "private_timelord",
+		},
+		"crawler": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateCrawler = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateCrawler },
+			certKeyBase: "private_crawler",
+		},
+		"data_layer": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateDatalayer = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateDatalayer },
+			certKeyBase: "private_data_layer",
+		},
+		"daemon": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PrivateDaemon = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PrivateDaemon },
+			certKeyBase: "private_daemon",
+		},
 	}
-	publicNodeNames = []string{
-		"full_node",
-		"wallet",
-		"farmer",
-		"introducer",
-		"timelord",
-		"data_layer",
+	publicNodes = map[string]fieldHelpers{
+		"full_node": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicFullNode = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicFullNode },
+			certKeyBase: "public_full_node",
+		},
+		"wallet": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicWallet = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicWallet },
+			certKeyBase: "public_wallet",
+		},
+		"farmer": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicFarmer = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicFarmer },
+			certKeyBase: "public_farmer",
+		},
+		"introducer": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicIntroducer = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicIntroducer },
+			certKeyBase: "public_introducer",
+		},
+		"timelord": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicTimelord = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicTimelord },
+			certKeyBase: "public_timelord",
+		},
+		"data_layer": {
+			setter:      func(c *ChiaCertificates, p *CertificateKeyPair) { c.PublicDatalayer = p },
+			getter:      func(c *ChiaCertificates) *CertificateKeyPair { return c.PublicDatalayer },
+			certKeyBase: "public_data_layer",
+		},
 	}
 
 	//go:embed chia_ca.crt
@@ -43,20 +105,149 @@ var (
 	chiaCAKeyBytes []byte
 )
 
-// GenerateAllCerts generates the full set of required certs for chia blockchain
+// ChiaCertificates contains the data for all Chia TLS certificate-key pairs
+type ChiaCertificates struct {
+	PrivateCA        *CertificateKeyPair
+	PrivateCrawler   *CertificateKeyPair
+	PrivateDaemon    *CertificateKeyPair
+	PrivateDatalayer *CertificateKeyPair
+	PublicDatalayer  *CertificateKeyPair
+	PrivateFarmer    *CertificateKeyPair
+	PublicFarmer     *CertificateKeyPair
+	PrivateFullNode  *CertificateKeyPair
+	PublicFullNode   *CertificateKeyPair
+	PrivateHarvester *CertificateKeyPair
+	PublicIntroducer *CertificateKeyPair
+	PrivateTimelord  *CertificateKeyPair
+	PublicTimelord   *CertificateKeyPair
+	PrivateWallet    *CertificateKeyPair
+	PublicWallet     *CertificateKeyPair
+}
+
+// CertificateKeyPair contains the data for a TLS certificate-key pair
+type CertificateKeyPair struct {
+	Certificate []byte
+	PrivateKey  *rsa.PrivateKey
+}
+
+// GenerateAllCerts  generates the full set of required certs for chia blockchain
 // If privateCACert and privateCAKey are both nil, a new private CA will be generated
-func GenerateAllCerts(outDir string, privateCACert *x509.Certificate, privateCAKey *rsa.PrivateKey) error {
+func GenerateAllCerts(privateCACert *x509.Certificate, privateCAKey *rsa.PrivateKey) (*ChiaCertificates, error) {
+	var chiaCerts *ChiaCertificates
+
+	if privateCACert == nil && privateCAKey == nil {
+		// If privateCACert and privateCAKey are both nil, we will generate a new one
+		var err error
+		var privateCACertDER []byte
+		privateCACertDER, privateCAKey, err = GenerateNewCA()
+		if err != nil {
+			return nil, fmt.Errorf("error creating private ca pair: %w", err)
+		}
+		privateCACertPEMBytes, privateCAKeyPEMBytes, err := EncodeCertAndKeyToPEM(privateCACertDER, privateCAKey)
+		if err != nil {
+			return nil, fmt.Errorf("error encoding private ca certificates: %w", err)
+		}
+		privateCACert, err = ParsePemCertificate(privateCACertPEMBytes)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing generated private_ca.crt: %w", err)
+		}
+		privateCAKeyPEM, err := ParsePemKey(privateCAKeyPEMBytes)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing generated private_ca.key: %w", err)
+		}
+		chiaCerts.PrivateCA = &CertificateKeyPair{
+			Certificate: privateCACertPEMBytes,
+			PrivateKey:  privateCAKeyPEM,
+		}
+	} else if privateCACert == nil || privateCAKey == nil {
+		// If only one of them is nil, we can't continue
+		return nil, errors.New("you must provide the CA cert and key if providing a CA, or set both to nil and a new CA will be generated")
+	} else {
+		// Must have non-nil values for both, so ensure the cert and key match
+		if !CertMatchesPrivateKey(privateCACert, privateCAKey) {
+			return nil, errors.New("provided private CA Cert and Key do not match")
+		}
+	}
+
+	// Parse public CA cert and key bytes
+	chiaCACert, err := ParsePemCertificate(chiaCACrtBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing chia_ca.crt")
+	}
+	chiaCAKey, err := ParsePemKey(chiaCAKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing chia_ca.key")
+	}
+
+	// Create all Certificate-Key pairs from public CA
+	for node, nodeData := range publicNodes {
+		cert, key, err := GenerateCASignedCert(chiaCACert, chiaCAKey)
+		if err != nil {
+			return nil, fmt.Errorf("error generating public pair for %s: %w", node, err)
+		}
+		nodeData.setter(chiaCerts, &CertificateKeyPair{
+			Certificate: cert,
+			PrivateKey:  key,
+		})
+	}
+
+	// Create all Certificate-Key pairs from private CA
+	for node, nodeData := range privateNodes {
+		cert, key, err := GenerateCASignedCert(privateCACert, privateCAKey)
+		if err != nil {
+			return nil, fmt.Errorf("error generating private pair for %s: %w", node, err)
+		}
+		nodeData.setter(chiaCerts, &CertificateKeyPair{
+			Certificate: cert,
+			PrivateKey:  key,
+		})
+	}
+
+	return chiaCerts, nil
+}
+
+// GenerateAndWriteAllCerts generates the full set of required certs for chia blockchain and writes them to a given directory
+// If privateCACert and privateCAKey are both nil, a new private CA will be generated
+func GenerateAndWriteAllCerts(outDir string, privateCACert *x509.Certificate, privateCAKey *rsa.PrivateKey) error {
 	// First, ensure that all output directories exist
-	allNodes := append(privateNodeNames, publicNodeNames...)
-	for _, subdir := range append(allNodes, "ca") {
+	allNodes := make(map[string]bool)
+	for k := range privateNodes {
+		allNodes[k] = true
+	}
+	for k := range publicNodes {
+		allNodes[k] = true
+	}
+	allNodes["ca"] = true
+	for subdir := range allNodes {
 		err := os.MkdirAll(path.Join(outDir, subdir), 0700)
 		if err != nil {
 			return fmt.Errorf("error making output directory for certs: %w", err)
 		}
 	}
 
+	// Generate all the certificates
+	allCerts, err := GenerateAllCerts(privateCACert, privateCAKey)
+	if err != nil {
+		return fmt.Errorf("error generating certificates: %w", err)
+	}
+
+	// Copy the private CA cert/key
+	err = os.WriteFile(path.Join(outDir, "ca", "private_ca.crt"), allCerts.PrivateCA.Certificate, 0600)
+	if err != nil {
+		return fmt.Errorf("error copying private_ca.crt: %w", err)
+	}
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(allCerts.PrivateCA.PrivateKey)
+	if err != nil {
+		return fmt.Errorf("error encoding private key to PKCS8: %w", err)
+	}
+	keyPemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+	err = os.WriteFile(path.Join(outDir, "ca", "private_ca.key"), keyPemBytes, 0600)
+	if err != nil {
+		return fmt.Errorf("error copying private_ca.key: %w", err)
+	}
+
 	// Next, copy the chia_ca cert/key
-	err := os.WriteFile(path.Join(outDir, "ca", "chia_ca.crt"), chiaCACrtBytes, 0600)
+	err = os.WriteFile(path.Join(outDir, "ca", "chia_ca.crt"), chiaCACrtBytes, 0600)
 	if err != nil {
 		return fmt.Errorf("error copying chia_ca.crt: %w", err)
 	}
@@ -65,60 +256,39 @@ func GenerateAllCerts(outDir string, privateCACert *x509.Certificate, privateCAK
 		return fmt.Errorf("error copying chia_ca.key: %w", err)
 	}
 
-	chiaCACert, err := ParsePemCertificate(chiaCACrtBytes)
-	if err != nil {
-		return fmt.Errorf("error parsing chia_ca.crt")
-	}
+	for node, nodeHelpers := range publicNodes {
+		crtKey := nodeHelpers.getter(allCerts)
+		err = os.WriteFile(path.Join(outDir, node, fmt.Sprintf("%s.crt", nodeHelpers.certKeyBase)), crtKey.Certificate, 0600)
+		if err != nil {
+			return fmt.Errorf("error copying %s.crt: %w", nodeHelpers.certKeyBase, err)
+		}
 
-	chiaCAKey, err := ParsePemKey(chiaCAKeyBytes)
-	if err != nil {
-		return fmt.Errorf("error parsing chia_ca.key")
-	}
-
-	if privateCACert == nil && privateCAKey == nil {
-		// If privateCACert and privateCAKey are both nil, we will generate a new one
-		var privateCACertDER []byte
-		privateCACertDER, privateCAKey, err = GenerateNewCA()
+		keyBytes, err := x509.MarshalPKCS8PrivateKey(crtKey.PrivateKey)
 		if err != nil {
-			return fmt.Errorf("error creating private ca pair: %w", err)
+			return fmt.Errorf("error encoding private key to PKCS8: %w", err)
 		}
-		privateCACertBytes, _, err := WriteCertAndKey(privateCACertDER, privateCAKey, path.Join(outDir, "ca", "private_ca"))
+		keyPemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+		err = os.WriteFile(path.Join(outDir, node, fmt.Sprintf("%s.key", nodeHelpers.certKeyBase)), keyPemBytes, 0600)
 		if err != nil {
-			return fmt.Errorf("error writing private ca: %w", err)
-		}
-		privateCACert, err = ParsePemCertificate(privateCACertBytes)
-		if err != nil {
-			return fmt.Errorf("error parsing generated private_ca.crt: %w", err)
-		}
-	} else if privateCACert == nil || privateCAKey == nil {
-		// If only one of them is nil, we can't continue
-		return errors.New("you must provide the CA cert and key if providing a CA, or set both to nil and a new CA will be generated")
-	} else {
-		// Must have non-nil values for both, so ensure the cert and key match
-		if !CertMatchesPrivateKey(privateCACert, privateCAKey) {
-			return errors.New("provided private CA Cert and Key do not match")
+			return fmt.Errorf("error copying %s.key: %w", nodeHelpers.certKeyBase, err)
 		}
 	}
 
-	for _, node := range publicNodeNames {
-		cert, key, err := GenerateCASignedCert(chiaCACert, chiaCAKey)
+	for node, nodeHelpers := range privateNodes {
+		crtKey := nodeHelpers.getter(allCerts)
+		err = os.WriteFile(path.Join(outDir, node, fmt.Sprintf("%s.crt", nodeHelpers.certKeyBase)), crtKey.Certificate, 0600)
 		if err != nil {
-			return fmt.Errorf("error generating public pair for %s: %w", node, err)
+			return fmt.Errorf("error copying %s.crt: %w", nodeHelpers.certKeyBase, err)
 		}
-		_, _, err = WriteCertAndKey(cert, key, path.Join(outDir, node, fmt.Sprintf("public_%s", node)))
-		if err != nil {
-			return fmt.Errorf("error writing public pair for %s: %w", node, err)
-		}
-	}
 
-	for _, node := range privateNodeNames {
-		cert, key, err := GenerateCASignedCert(privateCACert, privateCAKey)
+		keyBytes, err := x509.MarshalPKCS8PrivateKey(crtKey.PrivateKey)
 		if err != nil {
-			return fmt.Errorf("error generating private pair for %s: %w", node, err)
+			return fmt.Errorf("error encoding private key to PKCS8: %w", err)
 		}
-		_, _, err = WriteCertAndKey(cert, key, path.Join(outDir, node, fmt.Sprintf("private_%s", node)))
+		keyPemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+		err = os.WriteFile(path.Join(outDir, node, fmt.Sprintf("%s.key", nodeHelpers.certKeyBase)), keyPemBytes, 0600)
 		if err != nil {
-			return fmt.Errorf("error writing private pair for %s: %w", node, err)
+			return fmt.Errorf("error copying %s.key: %w", nodeHelpers.certKeyBase, err)
 		}
 	}
 

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -258,37 +258,17 @@ func GenerateAndWriteAllCerts(outDir string, privateCACert *x509.Certificate, pr
 
 	for node, nodeHelpers := range publicNodes {
 		crtKey := nodeHelpers.fetch(allCerts)
-		crt, key, err := EncodeCertAndKeyToPEM(crtKey.Certificate, crtKey.PrivateKey)
+		_, _, err = WriteCertAndKey(crtKey.Certificate, crtKey.PrivateKey, path.Join(outDir, node, nodeHelpers.certKeyBase))
 		if err != nil {
-			return fmt.Errorf("error encoding public pair for %s: %w", node, err)
-		}
-
-		err = os.WriteFile(path.Join(outDir, node, fmt.Sprintf("%s.crt", nodeHelpers.certKeyBase)), crt, 0600)
-		if err != nil {
-			return fmt.Errorf("error copying %s.crt: %w", nodeHelpers.certKeyBase, err)
-		}
-
-		err = os.WriteFile(path.Join(outDir, node, fmt.Sprintf("%s.key", nodeHelpers.certKeyBase)), key, 0600)
-		if err != nil {
-			return fmt.Errorf("error copying %s.key: %w", nodeHelpers.certKeyBase, err)
+			return fmt.Errorf("error writing private pair for %s: %w", node, err)
 		}
 	}
 
 	for node, nodeHelpers := range privateNodes {
 		crtKey := nodeHelpers.fetch(allCerts)
-		crt, key, err := EncodeCertAndKeyToPEM(crtKey.Certificate, crtKey.PrivateKey)
+		_, _, err = WriteCertAndKey(crtKey.Certificate, crtKey.PrivateKey, path.Join(outDir, node, nodeHelpers.certKeyBase))
 		if err != nil {
-			return fmt.Errorf("error encoding private pair for %s: %w", node, err)
-		}
-
-		err = os.WriteFile(path.Join(outDir, node, fmt.Sprintf("%s.crt", nodeHelpers.certKeyBase)), crt, 0600)
-		if err != nil {
-			return fmt.Errorf("error copying %s.crt: %w", nodeHelpers.certKeyBase, err)
-		}
-
-		err = os.WriteFile(path.Join(outDir, node, fmt.Sprintf("%s.key", nodeHelpers.certKeyBase)), key, 0600)
-		if err != nil {
-			return fmt.Errorf("error copying %s.key: %w", nodeHelpers.certKeyBase, err)
+			return fmt.Errorf("error writing private pair for %s: %w", node, err)
 		}
 	}
 

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -156,7 +156,7 @@ func GenerateAllCerts(privateCACert *x509.Certificate, privateCAKey *rsa.Private
 			return nil, fmt.Errorf("error parsing generated private_ca.key: %w", err)
 		}
 		chiaCerts.PrivateCA = &CertificateKeyPair{
-			Certificate: privateCACertPEMBytes,
+			Certificate: privateCACertDER,
 			PrivateKey:  privateCAKeyPEM,
 		}
 	} else if privateCACert == nil || privateCAKey == nil {
@@ -232,18 +232,9 @@ func GenerateAndWriteAllCerts(outDir string, privateCACert *x509.Certificate, pr
 	}
 
 	// Write the private CA cert/key
-	err = os.WriteFile(path.Join(outDir, "ca", "private_ca.crt"), allCerts.PrivateCA.Certificate, 0600)
+	_, _, err = WriteCertAndKey(allCerts.PrivateCA.Certificate, allCerts.PrivateCA.PrivateKey, path.Join(outDir, "ca", "private_ca"))
 	if err != nil {
-		return fmt.Errorf("error copying private_ca.crt: %w", err)
-	}
-	keyBytes, err := x509.MarshalPKCS8PrivateKey(allCerts.PrivateCA.PrivateKey)
-	if err != nil {
-		return fmt.Errorf("error encoding private key to PKCS8: %w", err)
-	}
-	keyPemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
-	err = os.WriteFile(path.Join(outDir, "ca", "private_ca.key"), keyPemBytes, 0600)
-	if err != nil {
-		return fmt.Errorf("error copying private_ca.key: %w", err)
+		return fmt.Errorf("error writing private ca: %w", err)
 	}
 
 	// Next, write the chia_ca cert/key

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -163,6 +163,10 @@ func GenerateAllCerts(privateCACert *x509.Certificate, privateCAKey *rsa.Private
 		if !CertMatchesPrivateKey(privateCACert, privateCAKey) {
 			return nil, errors.New("provided private CA Cert and Key do not match")
 		}
+		chiaCerts.PrivateCA = &CertificateKeyPair{
+			Certificate: privateCACert.Raw,
+			PrivateKey:  privateCAKey,
+		}
 	}
 
 	// Parse public CA cert and key bytes

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -143,7 +143,7 @@ func GenerateAllCerts(privateCACert *x509.Certificate, privateCAKey *rsa.Private
 		if err != nil {
 			return nil, fmt.Errorf("error creating private ca pair: %w", err)
 		}
-		privateCACertPEMBytes, privateCAKeyPEMBytes, err := EncodeCertAndKeyToPEM(privateCACertDER, privateCAKey)
+		privateCACertPEMBytes, _, err := EncodeCertAndKeyToPEM(privateCACertDER, privateCAKey)
 		if err != nil {
 			return nil, fmt.Errorf("error encoding private ca certificates: %w", err)
 		}
@@ -151,13 +151,9 @@ func GenerateAllCerts(privateCACert *x509.Certificate, privateCAKey *rsa.Private
 		if err != nil {
 			return nil, fmt.Errorf("error parsing generated private_ca.crt: %w", err)
 		}
-		privateCAKeyPEM, err := ParsePemKey(privateCAKeyPEMBytes)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing generated private_ca.key: %w", err)
-		}
 		chiaCerts.PrivateCA = &CertificateKeyPair{
 			Certificate: privateCACertDER,
-			PrivateKey:  privateCAKeyPEM,
+			PrivateKey:  privateCAKey,
 		}
 	} else if privateCACert == nil || privateCAKey == nil {
 		// If only one of them is nil, we can't continue

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -1,0 +1,193 @@
+package tls
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+)
+
+var testCertPEMBlock = []byte(`-----BEGIN CERTIFICATE-----
+MIIDVTCCAj2gAwIBAgIRAKo6h63J+hpNFV3CpKReWW8wDQYJKoZIhvcNAQELBQAw
+RDENMAsGA1UEChMEQ2hpYTEhMB8GA1UECxMYT3JnYW5pYyBGYXJtaW5nIERpdmlz
+aW9uMRAwDgYDVQQDEwdDaGlhIENBMB4XDTI1MDMyMTAwMzAyOFoXDTM1MDMyMTAw
+MzAyOFowRDENMAsGA1UEChMEQ2hpYTEhMB8GA1UECxMYT3JnYW5pYyBGYXJtaW5n
+IERpdmlzaW9uMRAwDgYDVQQDEwdDaGlhIENBMIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEAn0SIrAkL6tJH8HKMHVJlrx3hCogh2EBoECETv+I9k1/7Rlq+
+1vLK4MV2U+ei2rif18YVXM1gqOZFMnwtgYn9bu0L+aUC4fWYLIoQjaHW+RRC2+yU
+XjbmCR+qoYLa0628Kjmlrxq6zIu066sbn9pUOWI2C/AKO0vzD1bl3A5Qixyojl1o
+fXkBXW1Zo0Xbdx+dVzMBp17EDTB9vmhfnBseFdE1+OZZnmXbPKfwOxnPR4nvBNQu
+cYzPDlcEvjNXImG2Qo2fzy5HMyMkKO1tPgNQ+yGADMyYLiGkfWjYlRgQbaXmuYAD
+KZAOhhbW9rlfVJyZfzSmSqR7n2R8QWjM7kMpFwIDAQABo0IwQDAOBgNVHQ8BAf8E
+BAMCAoQwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU8B08DgU4J40PnA6q1p7E
+rDL3JRcwDQYJKoZIhvcNAQELBQADggEBAEA6lILY4I8k8+h3qSGCav5wdZFWL2cv
+9mUWqROxZwar3qaeD2FizzPguAES4tPPQ5poWA6UjTAV/8DA/YXKK4EwncMaDZLV
+iB4NXBcWcmf9XQ/BCIsLsWgwAsNMf8gxnQWdtSKLpPr1aNqYlsqbQ6c25Ro6Nsqd
+Op5+Ynd6Jyn+r+wnz4FG/zFz542RPwG2oIBKf+NOMnCKWBGsB4zpOVmLdimQNzp/
+HQg1t7/8Xig9/RX0nWs+cj9+iRVa9cxveQKCL9M8CQXnROYkLk35MSlmmVeU0WWJ
+R4l85xte60BXTq/nIFc2WRC78wTFzQc+TFCSgtTokCOtu7XpQJaRDWo=
+-----END CERTIFICATE-----`)
+
+var testKeyPEMBlock = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCfRIisCQvq0kfw
+cowdUmWvHeEKiCHYQGgQIRO/4j2TX/tGWr7W8srgxXZT56LauJ/XxhVczWCo5kUy
+fC2Bif1u7Qv5pQLh9ZgsihCNodb5FELb7JReNuYJH6qhgtrTrbwqOaWvGrrMi7Tr
+qxuf2lQ5YjYL8Ao7S/MPVuXcDlCLHKiOXWh9eQFdbVmjRdt3H51XMwGnXsQNMH2+
+aF+cGx4V0TX45lmeZds8p/A7Gc9Hie8E1C5xjM8OVwS+M1ciYbZCjZ/PLkczIyQo
+7W0+A1D7IYAMzJguIaR9aNiVGBBtpea5gAMpkA6GFtb2uV9UnJl/NKZKpHufZHxB
+aMzuQykXAgMBAAECggEAfr6RbSa93x98tHLT4jnCRfunLTRsiqWmqr9H8jne+rs1
+QiXRHUmV/g3mPptl1F18hsBSG8otE/w8MRL1O9NOZcoq735Lrvo9IaS1y6BxbUKc
+elvpLpjNs5EJvwJdlnr59ThvC8xfv4umbK18jFe5Evl/PTzHR60HPrvOrLKPkkP4
+1UNiqGGWfIOxdFbPvBiOFbcVJwGHVJ3TE/x/lMrdapW59hJZ5Rtxx5xUDR6EkkJd
+KOCI68zCiISUyEdfrKEfJPs/8LG9o9OgaxeBnGOtpxO0LyegC7tuuZ/TvuTaTQ0X
+cgrVXNuaCJfGmqPzpdATMdtQJoRVyF0Kt6dog7DgsQKBgQDJWWC2G6KUHNz6Phsp
+U3yYJSoKGWvPcZds5Fjfvy6eQEaOaU8aN+0XyWhgs/QetuOIbpfZid5ZgD6z0g9E
+4/a6mlgKKTl7CGnanKFxTGG2cXcBE96MMtPubQ0UurTqP++O7ZaC4m6TUCdt2MIy
+w+u6/ZLz/kFR73D3f8nRXTCwQwKBgQDKfydw1a2N0yRTdRvA/3CWzRIIosIGiHf0
+Tf4WCdCtPaftJ7l9Y1LdfV6BePp3dIyGmCHCACWvneei+qte2LMAky3fplIvjqBA
+pnWvBIrd+jZQgQFe6OEkUHiZ1RpPczXaxTwxekhpVTQay1og+3F0qLD4yS4Ae0nT
+NgWC7dOwnQKBgQCTRHoF+ER7THkb1t0K5vNUXKpY5KsD+TMmBAY08KJqQNzaQJAI
+vyr8oOVlBXniFSZqnWkXRU2J7NDvuQ5N9uZ5KXaHSAuwv0CdEr7KHXHCfU7rTNsT
+dAGqe7x7kuvMAaN3yLKzXGY//Po5z7aKZt490EXxi9++zAC2JZM5PI3l/QKBgEkd
+NjFwhZSyyufzXc0GrjFU5BEIK0ROm/ky++4bJySWIX7om/nhFfdxH+FhvBXLmD20
+ymOQyAqr2gonth6t4ZvwiFy7YetX9RbCw7Uoz7csc9YHbmZFcZ06DQGGR1SuhaBz
+HLPEskaOBB00lVtZTnLPwe5iPWDhIxvG4qCOnKOlAoGBALR/JAQysYGjkm8H7UM6
+H7ij3Gb3zSd+ziUMa7WxDCe8kBA5delHjzy8m8UrhmijpMJIOKk/5EwPEyCUnREZ
+5EFVojPksoBn2LY0ZrS59/xELtLd7Rs9kdKBOoUoBGRtHR5Dr0W9+yzTt3Zl3aJz
+Rb7RT3n8oEZxwPDlbW3OAVBH
+-----END PRIVATE KEY-----`)
+
+func TestGenerateAllCerts_ProvidedCA(t *testing.T) {
+	// Decode the PEM-encoded certificate to get DER format
+	certBlock, _ := pem.Decode(testCertPEMBlock)
+	if certBlock == nil {
+		t.Fatal("Failed to decode PEM block containing certificate")
+	}
+	// Convert DER to x509 Certificate
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse certificate: %v", err)
+	}
+
+	// Decode the PEM-encoded private key
+	keyBlock, _ := pem.Decode(testKeyPEMBlock)
+	if keyBlock == nil {
+		t.Fatal("Failed to decode PEM block containing private key")
+	}
+	// Parse the private key in PKCS#8 format
+	parsedKey, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse private key: %v", err)
+	}
+	// Type assert to RSA private key
+	privateKey, ok := parsedKey.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatal("Parsed key is not an RSA private key")
+	}
+
+	allCerts, err := GenerateAllCerts(cert, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to generate all certificates: %v", err)
+	}
+
+	// Test that private CA cert and private key match from the GenerateAllCerts output
+	privateCACert, err := x509.ParseCertificate(allCerts.PrivateCA.CertificateDER)
+	if err != nil {
+		t.Fatalf("Failed to parse private CA certificate: %v", err)
+	}
+	if !CertMatchesPrivateKey(privateCACert, allCerts.PrivateCA.PrivateKey) {
+		t.Fatal("Private CA certificate and private key do not match")
+	}
+
+	// Loop through all public certificate-key pairs and verify that the pair is not nil, that the key matches the certificate, and that they were signed by the public CA
+	for _, nodeHelpers := range publicNodes {
+		crtKey := nodeHelpers.fetch(allCerts)
+
+		// Test pair is not nil
+		if crtKey == nil || crtKey.PrivateKey == nil || crtKey.CertificateDER == nil || len(crtKey.CertificateDER) == 0 {
+			t.Fatalf("Certificate pair, or one of the certificate or key is empty : %s", nodeHelpers.certKeyBase)
+		}
+
+		// Test pair matches
+		cert, err := x509.ParseCertificate(crtKey.CertificateDER)
+		if err != nil {
+			t.Fatalf("Failed to parse certificate for %s: %v", nodeHelpers.certKeyBase, err)
+		}
+		if !CertMatchesPrivateKey(cert, crtKey.PrivateKey) {
+			t.Fatalf("certificate and private key do not match for %s", nodeHelpers.certKeyBase)
+		}
+	}
+
+	// Loop through all private certificate-key pairs and verify that the pair is not nil, that the key matches the certificate, and that they were signed by the private CA
+	for _, nodeHelpers := range privateNodes {
+		crtKey := nodeHelpers.fetch(allCerts)
+
+		// Test pair is not nil
+		if crtKey == nil || crtKey.PrivateKey == nil || crtKey.CertificateDER == nil || len(crtKey.CertificateDER) == 0 {
+			t.Fatalf("Certificate pair, or one of the certificate or key is empty : %s", nodeHelpers.certKeyBase)
+		}
+
+		// Test pair matches
+		cert, err := x509.ParseCertificate(crtKey.CertificateDER)
+		if err != nil {
+			t.Fatalf("Failed to parse certificate for %s: %v", nodeHelpers.certKeyBase, err)
+		}
+		if !CertMatchesPrivateKey(cert, crtKey.PrivateKey) {
+			t.Fatalf("certificate and private key do not match for %s", nodeHelpers.certKeyBase)
+		}
+	}
+}
+
+func TestGenerateAllCerts_GeneratedCA(t *testing.T) {
+	allCerts, err := GenerateAllCerts(nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to generate all certificates: %v", err)
+	}
+
+	// Test that private CA cert and private key match from the GenerateAllCerts output
+	privateCACert, err := x509.ParseCertificate(allCerts.PrivateCA.CertificateDER)
+	if err != nil {
+		t.Fatalf("Failed to parse private CA certificate: %v", err)
+	}
+	if !CertMatchesPrivateKey(privateCACert, allCerts.PrivateCA.PrivateKey) {
+		t.Fatal("Private CA certificate and private key do not match")
+	}
+
+	// Loop through all public certificate-key pairs and verify that the pair is not nil, that the key matches the certificate, and that they were signed by the public CA
+	for _, nodeHelpers := range publicNodes {
+		crtKey := nodeHelpers.fetch(allCerts)
+
+		// Test pair is not nil
+		if crtKey == nil || crtKey.PrivateKey == nil || crtKey.CertificateDER == nil || len(crtKey.CertificateDER) == 0 {
+			t.Fatalf("Certificate pair, or one of the certificate or key is empty : %s", nodeHelpers.certKeyBase)
+		}
+
+		// Test pair matches
+		cert, err := x509.ParseCertificate(crtKey.CertificateDER)
+		if err != nil {
+			t.Fatalf("Failed to parse certificate for %s: %v", nodeHelpers.certKeyBase, err)
+		}
+		if !CertMatchesPrivateKey(cert, crtKey.PrivateKey) {
+			t.Fatalf("certificate and private key do not match for %s", nodeHelpers.certKeyBase)
+		}
+	}
+
+	// Loop through all private certificate-key pairs and verify that the pair is not nil, that the key matches the certificate, and that they were signed by the private CA
+	for _, nodeHelpers := range privateNodes {
+		crtKey := nodeHelpers.fetch(allCerts)
+
+		// Test pair is not nil
+		if crtKey == nil || crtKey.PrivateKey == nil || crtKey.CertificateDER == nil || len(crtKey.CertificateDER) == 0 {
+			t.Fatalf("Certificate pair, or one of the certificate or key is empty : %s", nodeHelpers.certKeyBase)
+		}
+
+		// Test pair matches
+		cert, err := x509.ParseCertificate(crtKey.CertificateDER)
+		if err != nil {
+			t.Fatalf("Failed to parse certificate for %s: %v", nodeHelpers.certKeyBase, err)
+		}
+		if !CertMatchesPrivateKey(cert, crtKey.PrivateKey) {
+			t.Fatalf("certificate and private key do not match for %s", nodeHelpers.certKeyBase)
+		}
+	}
+}

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -99,7 +99,7 @@ func TestGenerateAllCerts_ProvidedCA(t *testing.T) {
 		t.Fatal("Private CA certificate and private key do not match")
 	}
 
-	// Loop through all public certificate-key pairs and verify that the pair is not nil, that the key matches the certificate, and that they were signed by the public CA
+	// Loop through all public certificate-key pairs and verify that the pair is not nil, that the key matches the certificate
 	for _, nodeHelpers := range publicNodes {
 		crtKey := nodeHelpers.fetch(allCerts)
 
@@ -118,7 +118,7 @@ func TestGenerateAllCerts_ProvidedCA(t *testing.T) {
 		}
 	}
 
-	// Loop through all private certificate-key pairs and verify that the pair is not nil, that the key matches the certificate, and that they were signed by the private CA
+	// Loop through all private certificate-key pairs and verify that the pair is not nil, that the key matches the certificate
 	for _, nodeHelpers := range privateNodes {
 		crtKey := nodeHelpers.fetch(allCerts)
 
@@ -153,7 +153,7 @@ func TestGenerateAllCerts_GeneratedCA(t *testing.T) {
 		t.Fatal("Private CA certificate and private key do not match")
 	}
 
-	// Loop through all public certificate-key pairs and verify that the pair is not nil, that the key matches the certificate, and that they were signed by the public CA
+	// Loop through all public certificate-key pairs and verify that the pair is not nil, that the key matches the certificate
 	for _, nodeHelpers := range publicNodes {
 		crtKey := nodeHelpers.fetch(allCerts)
 
@@ -172,7 +172,7 @@ func TestGenerateAllCerts_GeneratedCA(t *testing.T) {
 		}
 	}
 
-	// Loop through all private certificate-key pairs and verify that the pair is not nil, that the key matches the certificate, and that they were signed by the private CA
+	// Loop through all private certificate-key pairs and verify that the pair is not nil, that the key matches the certificate
 	for _, nodeHelpers := range privateNodes {
 		crtKey := nodeHelpers.fetch(allCerts)
 


### PR DESCRIPTION
NOTE: Breaking change introduced for all existing users of GenerateAllCerts. That function was moved to GenerateAndWriteAllCerts with the same usage, and calls the new GenerateAllCerts which just produces a struct of the cert-key pairs in memory in a format that can be consumed by EncodeCertAndKeyToPEM.