### PR TITLE
Include transaction ID in output

### DIFF
--- a/pkg/rpc/wallet.go
+++ b/pkg/rpc/wallet.go
@@ -470,8 +470,9 @@ type SplitCoinsOptions struct {
 // SplitCoinsResponse response from split_coins
 type SplitCoinsResponse struct {
 	rpcinterface.Response
-	TransactionID mo.Option[string]                  `json:"transaction_id"`
-	Transaction   mo.Option[types.TransactionRecord] `json:"transaction"`
+	TransactionID mo.Option[string]                    `json:"transaction_id"`
+	Transaction   mo.Option[types.TransactionRecord]   `json:"transaction"`
+	Transactions  mo.Option[[]types.TransactionRecord] `json:"transactions"`
 }
 
 // SplitCoins splits a coin into multiple smaller coins

--- a/pkg/rpc/wallet.go
+++ b/pkg/rpc/wallet.go
@@ -470,9 +470,7 @@ type SplitCoinsOptions struct {
 // SplitCoinsResponse response from split_coins
 type SplitCoinsResponse struct {
 	rpcinterface.Response
-	TransactionID mo.Option[string]                    `json:"transaction_id"`
-	Transaction   mo.Option[types.TransactionRecord]   `json:"transaction"`
-	Transactions  mo.Option[[]types.TransactionRecord] `json:"transactions"`
+	Transactions mo.Option[[]types.TransactionRecord] `json:"transactions"`
 }
 
 // SplitCoins splits a coin into multiple smaller coins


### PR DESCRIPTION
Pass the transaction ID returned by the RPC for use by chia-tools upstream.  