### PR TITLE
Add exempt peer network support for wallet

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -542,6 +542,8 @@ type WalletConfig struct {
 	// trusted_cidrs allows marking certain nodes as "trusted" in the full node and wallet
 	// Not in the initial config anywhere, since it's a more advanced option
 	TrustedCIDRs []string `yaml:"trusted_cidrs,omitempty" json:"trusted_cidrs,omitempty"`
+	// exempt_peer_networks is supported by the wallet but omitted from the initial config
+	ExemptPeerNetworks []string `yaml:"exempt_peer_networks,omitempty" json:"exempt_peer_networks,omitempty"`
 }
 
 // SolverConfig solver configuration section

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -61,6 +61,73 @@ rate_limits: 3
 	})
 }
 
+func TestWalletExemptPeerNetworksOptional(t *testing.T) {
+	t.Run("default config omits wallet exempt_peer_networks", func(t *testing.T) {
+		cfg, err := config.LoadDefaultConfig()
+		require.NoError(t, err)
+		assert.Empty(t, cfg.Wallet.ExemptPeerNetworks)
+
+		out, err := yaml.Marshal(cfg.Wallet)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "exempt_peer_networks")
+	})
+
+	t.Run("marshal omits empty, includes when set", func(t *testing.T) {
+		wallet := config.WalletConfig{}
+
+		out, err := yaml.Marshal(wallet)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "exempt_peer_networks")
+
+		wallet.ExemptPeerNetworks = []string{}
+		out, err = yaml.Marshal(wallet)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "exempt_peer_networks")
+
+		wallet.ExemptPeerNetworks = []string{"192.168.1.0/24", "fe80::/10"}
+		out, err = yaml.Marshal(wallet)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "exempt_peer_networks:")
+		assert.Contains(t, string(out), "192.168.1.0/24")
+		assert.Contains(t, string(out), "fe80::/10")
+	})
+
+	t.Run("unmarshal absent yields empty and is omitted on remarshal", func(t *testing.T) {
+		var wallet config.WalletConfig
+		require.NoError(t, yaml.Unmarshal([]byte(`db_sync: auto`), &wallet))
+		assert.Empty(t, wallet.ExemptPeerNetworks)
+
+		out, err := yaml.Marshal(wallet)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "exempt_peer_networks")
+	})
+
+	t.Run("unmarshal empty list is omitted on remarshal", func(t *testing.T) {
+		var wallet config.WalletConfig
+		require.NoError(t, yaml.Unmarshal([]byte(`exempt_peer_networks: []`), &wallet))
+		assert.Empty(t, wallet.ExemptPeerNetworks)
+
+		out, err := yaml.Marshal(wallet)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "exempt_peer_networks")
+	})
+
+	t.Run("unmarshal present retains value on remarshal", func(t *testing.T) {
+		var wallet config.WalletConfig
+		require.NoError(t, yaml.Unmarshal([]byte(`exempt_peer_networks:
+  - 192.168.1.0/24
+  - fe80::/10
+`), &wallet))
+		assert.Equal(t, []string{"192.168.1.0/24", "fe80::/10"}, wallet.ExemptPeerNetworks)
+
+		out, err := yaml.Marshal(wallet)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "exempt_peer_networks:")
+		assert.Contains(t, string(out), "192.168.1.0/24")
+		assert.Contains(t, string(out), "fe80::/10")
+	})
+}
+
 func TestNFTAutoAddLimitPointer(t *testing.T) {
 	t.Run("marshal omits nil, includes zero and non-zero", func(t *testing.T) {
 		wallet := config.WalletConfig{}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config schema and serialization only in go-chia-libs; no peer-handling logic changes in this PR.
> 
> **Overview**
> Adds **`exempt_peer_networks`** to **`WalletConfig`** so wallet YAML can list CIDRs that exempt peers from certain limits, aligned with full-node’s existing field but kept **optional** via `omitempty` so shipped defaults stay unchanged.
> 
> **`TestWalletExemptPeerNetworksOptional`** locks in YAML behavior: absent or empty lists are omitted on marshal; non-empty values (e.g. `192.168.1.0/24`) round-trip correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce55e0bdbe09d4506e018221323becd0679457b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->